### PR TITLE
Update pathways-job_v1_pathwaysjob.yaml

### DIFF
--- a/config/samples/pathways-job_v1_pathwaysjob.yaml
+++ b/config/samples/pathways-job_v1_pathwaysjob.yaml
@@ -40,4 +40,4 @@ spec:
             pip install --upgrade pip
             pip install -U --pre jax jaxlib -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
             pip install pathwaysutils
-            python -c "import jax; import pathwaysutils; print(\"Number of JAX devices is\", len(jax.devices()))"
+            python -c "import jax; import pathwaysutils; pathwaysutils.initialize(); print(\"Number of JAX devices is\", len(jax.devices()))"


### PR DESCRIPTION
Fix sample yaml config to initialize pathways before scanning devices.

Without initializing pathways, Jax won't recognize 'proxy' backend.